### PR TITLE
Now we can add any Tequila parameter in :additional_parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ OmniAuth Tequila authenticates with the EPFL server over SSL by default. However
   * `ca_path` - Optional when `ssl` is `true`. Sets path of a CA certification directory. See [Net::HTTP][net_http] for more details
   * `uid_field` - The user data attribute to use as your user's unique identifier. Defaults to `'uniqueid'` (which contains the user's SCIPER number when using EPFL's Tequila server)
   * `request_info` - Hash that maps user attributes from Tequila to the [OmniAuth schema][omniauth_schema]. Defaults to `{ :name => 'displayname' }` (which is the user's full name when using EPFL's Tequila server)
+  * `additional_parameters` - Hash that takes key - value pairs for any other parameter than those listed above. Defaults to `{}` (Empty hash)
 
 If you encounter problems wih SSL certificates you may want to set the `ca_path` parameter or activate `disable_ssl_verification` (not recommended).
 

--- a/lib/omniauth/strategies/tequila.rb
+++ b/lib/omniauth/strategies/tequila.rb
@@ -21,6 +21,7 @@ module OmniAuth
       option :ssl, true
       option :uid_field, :uniqueid
       option :request_info, { :name => 'displayname' }
+      option :additional_parameters, {}
 
       # As required by https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema
       info do
@@ -95,10 +96,13 @@ module OmniAuth
         # NB: You might want to set the service and required group yourself.
         request_fields = @options[:request_info].values << @options[:uid_field]
         body = 'urlaccess=' + callback_url + "\nservice=" + @options[:service_name] + "\n" +
-          'request=' + request_fields.join(',') 
-        if @options[:require_group] 
+          'request=' + request_fields.join(',')
+        if @options[:require_group]
           body += "\nrequire=group=" + @options[:require_group]
         end
+
+        @options[:additional_parameters].each { |param, value| body += "\n" + param + "=" + value}
+        
         tequila_post '/createrequest', body
       end
 

--- a/lib/omniauth/tequila/version.rb
+++ b/lib/omniauth/tequila/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Tequila
-    VERSION = '0.0.3'
+    VERSION = '0.1.0'
   end
 end


### PR DESCRIPTION
Hi !
As @twowordbird has been inactive on GitHub for a while, I also pull request you.
I made this change to be able to add the parameter: 'identities' => 'one'. This can be important if someone has several accreditations. We can add any other parameter in :additional_parameters as long as Tequila knows it.

Tested on rails 5.1 and ruby 2.4.1.